### PR TITLE
introduce parallelism to top n search

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - main
+    - master
   pull_request:
 name: Tests
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
     - master
+    - main
   pull_request:
 name: Tests
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 name: Tests
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	github.com/blugelabs/ice v1.0.0
 	github.com/caio/go-tdigest v3.1.0+incompatible
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 // indirect
 	github.com/spf13/cobra v0.0.5
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	golang.org/x/text v0.3.0
 	gonum.org/v1/gonum v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/blugelabs/bluge_segment_api v0.2.0
 	github.com/blugelabs/ice v1.0.0
 	github.com/caio/go-tdigest v3.1.0+incompatible
+	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 // indirect
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a

--- a/go.sum
+++ b/go.sum
@@ -36,10 +36,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -82,6 +78,8 @@ golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,12 @@ github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fp
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/index/snapshot.go
+++ b/index/snapshot.go
@@ -823,5 +823,6 @@ func (dvr *documentValueReader) VisitDocumentValues(number uint64,
 		}
 	}
 
-	return dvr.sdvr.VisitDocumentValues(localDocNum, visitor)
+	err = dvr.sdvr.VisitDocumentValues(localDocNum, visitor)
+	return err
 }

--- a/index/snapshot.go
+++ b/index/snapshot.go
@@ -802,7 +802,6 @@ type documentValueReader struct {
 	sdvr   segment.DocumentValueReader
 
 	currSegmentIndex int
-	lock             sync.Mutex
 }
 
 func (dvr *documentValueReader) VisitDocumentValues(number uint64,
@@ -812,8 +811,6 @@ func (dvr *documentValueReader) VisitDocumentValues(number uint64,
 		return nil
 	}
 
-	dvr.lock.Lock()
-	defer dvr.lock.Unlock()
 	if dvr.currSegmentIndex != segmentIndex {
 		dvr.currSegmentIndex = segmentIndex
 		sdvr, err := dvr.i.segment[dvr.currSegmentIndex].segment.DocumentValueReader(dvr.fields)
@@ -835,6 +832,5 @@ func (dvr *documentValueReader) VisitDocumentValues(number uint64,
 		}
 	}
 
-	err = dvr.sdvr.VisitDocumentValues(localDocNum, visitor)
-	return err
+	return dvr.sdvr.VisitDocumentValues(localDocNum, visitor)
 }

--- a/index/snapshot.go
+++ b/index/snapshot.go
@@ -790,6 +790,7 @@ type documentValueReader struct {
 	sdvr   segment.DocumentValueReader
 
 	currSegmentIndex int
+	lock             sync.Mutex
 }
 
 func (dvr *documentValueReader) VisitDocumentValues(number uint64,
@@ -799,6 +800,8 @@ func (dvr *documentValueReader) VisitDocumentValues(number uint64,
 		return nil
 	}
 
+	dvr.lock.Lock()
+	defer dvr.lock.Unlock()
 	if dvr.currSegmentIndex != segmentIndex {
 		dvr.currSegmentIndex = segmentIndex
 		sdvr, err := dvr.i.segment[dvr.currSegmentIndex].segment.DocumentValueReader(dvr.fields)

--- a/index/snapshot.go
+++ b/index/snapshot.go
@@ -804,6 +804,7 @@ type documentValueReader struct {
 	currSegmentIndex int
 }
 
+// TODO: possible concurrent load doc values in top n collector and lock here the documentValueReader here
 func (dvr *documentValueReader) VisitDocumentValues(number uint64,
 	visitor segment.DocumentValueVisitor) (err error) {
 	segmentIndex, localDocNum := dvr.i.segmentIndexAndLocalDocNumFromGlobal(number)

--- a/index_test.go
+++ b/index_test.go
@@ -1766,7 +1766,7 @@ func TestBug87(t *testing.T) {
 	// create 1025 documents in a batch
 	// this should require more than one chunk in doc values
 	batch := NewBatch()
-	for i := 0; i < 1025*2; i++ {
+	for i := 0; i < 1025; i++ {
 		doc := NewDocument(fmt.Sprintf("%d", i)).
 			AddField(NewTextField("name", "marty").Sortable())
 		batch.Update(doc.ID(), doc)

--- a/index_test.go
+++ b/index_test.go
@@ -1766,7 +1766,7 @@ func TestBug87(t *testing.T) {
 	// create 1025 documents in a batch
 	// this should require more than one chunk in doc values
 	batch := NewBatch()
-	for i := 0; i < 1025; i++ {
+	for i := 0; i < 1025*2; i++ {
 		doc := NewDocument(fmt.Sprintf("%d", i)).
 			AddField(NewTextField("name", "marty").Sortable())
 		batch.Update(doc.ID(), doc)

--- a/multisearch.go
+++ b/multisearch.go
@@ -120,7 +120,6 @@ func MultiSearch(ctx context.Context, req SearchRequest, readers ...*Reader) (se
 	if err != nil {
 		return nil, err
 	}
-	//log.SetOutput(os.Stderr)
 	log.Printf("multisearch query time: %dms", time.Since(start).Microseconds())
 
 	return dmItr, nil

--- a/multisearch.go
+++ b/multisearch.go
@@ -80,7 +80,6 @@ func (m *MultiSearcherList) collectAllDocuments(ctx *search.Context) {
 // A dilemma here, should MultiSearcherList.Next listen on finishedCollecting and then begin dispersing documents?
 // or just return documents directly from docChan?
 func (m *MultiSearcherList) storeDocs() {
-	seen := map[*search.DocumentMatch]bool{}
 	for {
 		match, ok := <-m.docChan
 		if !ok {
@@ -88,10 +87,7 @@ func (m *MultiSearcherList) storeDocs() {
 			return
 		}
 
-		if !seen[match] {
-			m.docs = append(m.docs, match)
-			seen[match] = true
-		}
+		m.docs = append(m.docs, match)
 	}
 }
 
@@ -146,7 +142,7 @@ func MultiSearch(ctx context.Context, req SearchRequest, readers ...*Reader) (se
 		}
 		searchers = append(searchers, searcher)
 	}
-	fmt.Println("time spent arranging readers: ", time.Since(start).Microseconds())
+	fmt.Println("time spent arranging readers: ", time.Since(start).Milliseconds())
 
 	msl := NewMultiSearcherList(searchers)
 	dmItr, err := collector.Collect(ctx, req.Aggregations(), msl)

--- a/multisearch.go
+++ b/multisearch.go
@@ -32,6 +32,7 @@ func NewMultiSearcherList(searchers []search.Searcher) *MultiSearcherList {
 	}
 }
 
+// TODO: this is also a source of expensive calls, parallelise this as well
 func (m *MultiSearcherList) Next(ctx *search.Context) (*search.DocumentMatch, error) {
 	if m.err != nil {
 		return nil, m.err

--- a/multisearch.go
+++ b/multisearch.go
@@ -16,7 +16,6 @@ package bluge
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -121,7 +120,8 @@ func MultiSearch(ctx context.Context, req SearchRequest, readers ...*Reader) (se
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("multisearch query time: %dms", time.Since(start).Microseconds())
+	//log.SetOutput(os.Stderr)
+	log.Printf("multisearch query time: %dms", time.Since(start).Microseconds())
 
 	return dmItr, nil
 }

--- a/multisearch.go
+++ b/multisearch.go
@@ -46,7 +46,7 @@ func NewMultiSearcherList(searchers []search.Searcher) *MultiSearcherList {
 }
 
 // if one searcher fails, should stop all the rest and exit?
-func (m *MultiSearcherList) collectAllDocuments(ctx *search.Context) {
+func (m *MultiSearcherList) collectAllDocuments(ctx search.Context) {
 	errs := &multierror.Group{}
 
 	var numFailed int64 = 0
@@ -91,8 +91,7 @@ func (m *MultiSearcherList) storeDocs() {
 	}
 }
 
-// TODO: this is also a source of expensive calls, parallelise this as well
-func (m *MultiSearcherList) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (m *MultiSearcherList) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	m.once.Do(func() {
 		go m.collectAllDocuments(ctx)
 		go m.storeDocs() // see comment on storeDocs

--- a/multisearch.go
+++ b/multisearch.go
@@ -49,7 +49,7 @@ func NewMultiSearcherList(searchers []search.Searcher) *MultiSearcherList {
 func (m *MultiSearcherList) collectAllDocuments(ctx search.Context) {
 	errs := &multierror.Group{}
 
-	var numFailed int64 = 0
+	var numFailed int64
 	for _, searcher := range m.searchers {
 		s := searcher
 		errs.Go(func() error {

--- a/multisearch_test.go
+++ b/multisearch_test.go
@@ -67,7 +67,7 @@ func TestMultiSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting index reader: %v", err)
 	}
-	err = prepareDocs(indexWriter1, 1000)
+	err = prepareDocs(indexWriter1, 500)
 	if err != nil {
 		t.Fatalf("error preparing docs: %v", err)
 	}

--- a/multisearch_test.go
+++ b/multisearch_test.go
@@ -67,7 +67,10 @@ func TestMultiSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting index reader: %v", err)
 	}
-	prepareDocs(indexWriter1, 1000)
+	err = prepareDocs(indexWriter1, 1000)
+	if err != nil {
+		t.Fatalf("error preparing docs: %v", err)
+	}
 
 	q := NewPrefixQuery("index-").SetField("name")
 	req := NewTopNSearch(10, q).WithStandardAggregations()

--- a/multisearch_test.go
+++ b/multisearch_test.go
@@ -16,7 +16,11 @@ package bluge
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestMultiSearch(t *testing.T) {
@@ -63,10 +67,12 @@ func TestMultiSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting index reader: %v", err)
 	}
+	prepareDocs(indexWriter1, 5000)
 
 	q := NewPrefixQuery("index-").SetField("name")
-	req := NewTopNSearch(10, q).WithStandardAggregations()
+	req := NewTopNSearch(6, q).WithStandardAggregations()
 
+	start := time.Now()
 	dmi, err := MultiSearch(context.Background(), req, indexReader1, indexReader2)
 	if err != nil {
 		t.Fatalf("error starting multisearch: %v", err)
@@ -77,6 +83,7 @@ func TestMultiSearch(t *testing.T) {
 		hitCount++
 		next, err = dmi.Next()
 	}
+	fmt.Printf("query time: %d", time.Since(start).Milliseconds())
 	if err != nil {
 		t.Fatalf("error iterating results")
 	}
@@ -101,4 +108,18 @@ func TestMultiSearch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Error("fake")
+}
+
+func prepareDocs(iw *Writer, n int) error {
+	for i := 0; i < n; i++ {
+		doc := NewDocument("a").
+			AddField(NewKeywordField("name", "index-"+uuid.NewString()))
+
+		err := iw.Update(doc.ID(), doc)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/multisearch_test.go
+++ b/multisearch_test.go
@@ -67,7 +67,7 @@ func TestMultiSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting index reader: %v", err)
 	}
-	prepareDocs(indexWriter1, 5000)
+	prepareDocs(indexWriter1, 1000)
 
 	q := NewPrefixQuery("index-").SetField("name")
 	req := NewTopNSearch(10, q).WithStandardAggregations()
@@ -108,7 +108,6 @@ func TestMultiSearch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Error("fake")
 }
 
 func prepareDocs(iw *Writer, n int) error {

--- a/multisearch_test.go
+++ b/multisearch_test.go
@@ -70,7 +70,7 @@ func TestMultiSearch(t *testing.T) {
 	prepareDocs(indexWriter1, 5000)
 
 	q := NewPrefixQuery("index-").SetField("name")
-	req := NewTopNSearch(6, q).WithStandardAggregations()
+	req := NewTopNSearch(10, q).WithStandardAggregations()
 
 	start := time.Now()
 	dmi, err := MultiSearch(context.Background(), req, indexReader1, indexReader2)

--- a/reader.go
+++ b/reader.go
@@ -76,7 +76,7 @@ func (r *Reader) Search(ctx context.Context, req SearchRequest) (search.Document
 	}
 
 	var dmItr search.DocumentMatchIterator
-	dmItr, err = collector.Collect(ctx, req.Aggregations(), searcher)
+	dmItr, err = collector.Collect(ctx, req.Aggregations(), searcher, search.PoolTypeSlice)
 	if err != nil {
 		return nil, err
 	}

--- a/search.go
+++ b/search.go
@@ -258,7 +258,7 @@ func memNeededForSearch(
 	// overhead, size in bytes from collector
 	estimate += coll.Size()
 
-	// pre-allocing DocumentMatchPool
+	// pre-allocing DocumentMatchSlicePool
 	estimate += searchContextEmptySize + numDocMatches*documentMatchEmptySize
 
 	// searcher overhead

--- a/search/aggregations/aggregtation_test.go
+++ b/search/aggregations/aggregtation_test.go
@@ -32,7 +32,7 @@ func TestAggregations(t *testing.T) {
 	bucket := search.NewBucket("global", global)
 	testDocs := buildTestDocs()
 	for _, doc := range testDocs {
-		err := doc.LoadDocumentValues(search.NewSearchContext(0, 0), global.Fields())
+		err := doc.LoadDocumentValues(search.NewSearchContext(0, 0, search.PoolTypeSlice), global.Fields())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -54,7 +54,7 @@ func TestAggregationMerge(t *testing.T) {
 	// process the first 5 docs in shard1
 	shard1 := search.NewBucket("shard1", global)
 	for _, doc := range testDocs[0:5] {
-		err := doc.LoadDocumentValues(search.NewSearchContext(0, 0), global.Fields())
+		err := doc.LoadDocumentValues(search.NewSearchContext(0, 0, search.PoolTypeSlice), global.Fields())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -65,7 +65,7 @@ func TestAggregationMerge(t *testing.T) {
 	// process the next 5 docs in shard2
 	shard2 := search.NewBucket("shard2", global)
 	for _, doc := range testDocs[5:] {
-		err := doc.LoadDocumentValues(search.NewSearchContext(0, 0), global.Fields())
+		err := doc.LoadDocumentValues(search.NewSearchContext(0, 0, search.PoolTypeSlice), global.Fields())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/search/collector.go
+++ b/search/collector.go
@@ -19,7 +19,7 @@ import (
 )
 
 type Collector interface {
-	Collect(context.Context, Aggregations, Collectible) (DocumentMatchIterator, error)
+	Collect(context.Context, Aggregations, Collectible, PoolType) (DocumentMatchIterator, error)
 
 	Size() int
 	BackingSize() int

--- a/search/collector.go
+++ b/search/collector.go
@@ -26,7 +26,7 @@ type Collector interface {
 }
 
 type Collectible interface {
-	Next(ctx *Context) (*DocumentMatch, error)
+	Next(ctx Context) (*DocumentMatch, error)
 	DocumentMatchPoolSize() int
 	Close() error
 }

--- a/search/collector/all.go
+++ b/search/collector/all.go
@@ -28,13 +28,13 @@ func NewAllCollector() *AllCollector {
 }
 
 func (a *AllCollector) Collect(ctx context.Context, aggs search.Aggregations,
-	searcher search.Collectible) (search.DocumentMatchIterator, error) {
+	searcher search.Collectible, poolType search.PoolType) (search.DocumentMatchIterator, error) {
 	iter := &AllIterator{
 		ctx:           ctx,
 		neededFields:  aggs.Fields(),
 		bucket:        search.NewBucket("", aggs),
 		searcher:      searcher,
-		searchContext: search.NewSearchContext(searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice),
+		searchContext: search.NewSearchContext(searcher.DocumentMatchPoolSize(), 0, poolType),
 	}
 	if len(iter.neededFields) <= 1 {
 		return iter, nil

--- a/search/collector/all.go
+++ b/search/collector/all.go
@@ -34,7 +34,7 @@ func (a *AllCollector) Collect(ctx context.Context, aggs search.Aggregations,
 		neededFields:  aggs.Fields(),
 		bucket:        search.NewBucket("", aggs),
 		searcher:      searcher,
-		searchContext: search.NewSearchContext(searcher.DocumentMatchPoolSize(), 0),
+		searchContext: search.NewSearchContext(searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice),
 	}
 	if len(iter.neededFields) <= 1 {
 		return iter, nil
@@ -66,7 +66,7 @@ type AllIterator struct {
 	bucket        *search.Bucket
 	hitNumber     int
 	searcher      search.Collectible
-	searchContext *search.Context
+	searchContext search.Context
 	done          bool
 }
 

--- a/search/collector/all.go
+++ b/search/collector/all.go
@@ -101,7 +101,7 @@ func (a *AllIterator) Next() (next *search.DocumentMatch, err error) {
 	}
 
 	a.hitNumber++
-	next.HitNumber = a.hitNumber
+	next.HitNumber = int64(a.hitNumber)
 
 	if len(a.neededFields) > 0 {
 		err = next.LoadDocumentValues(a.searchContext, a.neededFields)

--- a/search/collector/all_test.go
+++ b/search/collector/all_test.go
@@ -32,7 +32,7 @@ func TestAllCollector(t *testing.T) {
 	aggs.Add("count", aggregations.CountMatches())
 
 	collector := NewAllCollector()
-	dmi, err := collector.Collect(context.Background(), aggs, searcher)
+	dmi, err := collector.Collect(context.Background(), aggs, searcher, search.PoolTypeSlice)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/collector/bench_test.go
+++ b/search/collector/bench_test.go
@@ -47,7 +47,7 @@ func benchHelper(numOfMatches int, cc createCollector, b *testing.B) {
 		aggs := make(search.Aggregations)
 		aggs.Add("count", aggregations.CountMatches())
 		aggs.Add("max_score", aggregations.Max(search.DocumentScore()))
-		dmi, err := collector.Collect(context.Background(), aggs, searcher)
+		dmi, err := collector.Collect(context.Background(), aggs, searcher, search.PoolTypeSlice)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/search/collector/search_test.go
+++ b/search/collector/search_test.go
@@ -23,9 +23,9 @@ type stubSearcher struct {
 	matches []*search.DocumentMatch
 }
 
-func (ss *stubSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (ss *stubSearcher) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	if ss.index < len(ss.matches) {
-		rv := ctx.DocumentMatchPool.Get()
+		rv := ctx.GetDocumentMatchFromPool()
 		rv.Number = ss.matches[ss.index].Number
 		rv.Score = ss.matches[ss.index].Score
 		ss.index++

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -16,9 +16,7 @@ package collector
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
-	"time"
 
 	"github.com/blugelabs/bluge/search"
 	"github.com/hashicorp/go-multierror"
@@ -166,7 +164,6 @@ func (hc *TopNCollector) Collect(ctx context.Context, aggs search.Aggregations,
 
 	bucket := search.NewBucket("", aggs)
 
-	start := time.Now()
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -200,9 +197,12 @@ func (hc *TopNCollector) Collect(ctx context.Context, aggs search.Aggregations,
 		next, err = searcher.Next(searchContext)
 	}
 
-	multiErr := errs.Wait().ErrorOrNil()
+	// check searcher.Next error
+	if err != nil {
+		return nil, err
+	}
 
-	fmt.Println("time spent processing docs: ", time.Since(start).Seconds())
+	multiErr := errs.Wait().ErrorOrNil()
 
 	if multiErr != nil {
 		return nil, multiErr

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -126,7 +126,7 @@ func (hc *TopNCollector) BackingSize() int {
 
 // Collect goes to the index to find the matching documents
 func (hc *TopNCollector) Collect(ctx context.Context, aggs search.Aggregations,
-	searcher search.Collectible) (search.DocumentMatchIterator, error) {
+	searcher search.Collectible, poolType search.PoolType) (search.DocumentMatchIterator, error) {
 	var err error
 	var next *search.DocumentMatch
 
@@ -135,7 +135,7 @@ func (hc *TopNCollector) Collect(ctx context.Context, aggs search.Aggregations,
 		_ = searcher.Close()
 	}()
 
-	searchContext := search.NewSearchContext(hc.backingSize+searcher.DocumentMatchPoolSize(), len(hc.sort), search.PoolTypeSyncPool)
+	searchContext := search.NewSearchContext(hc.backingSize+searcher.DocumentMatchPoolSize(), len(hc.sort), poolType)
 
 	// add fields needed by aggregations
 	hc.neededFields = append(hc.neededFields, aggs.Fields()...)

--- a/search/collector/topn.go
+++ b/search/collector/topn.go
@@ -235,7 +235,7 @@ func (hc *TopNCollector) collectSingle(ctx *search.Context, d *search.DocumentMa
 		}
 	}
 
-	d.PipelineFinished = make(chan struct{}, 1)
+	d.PipelineFinished = make(chan struct{})
 
 	hc.sortPipeline <- d
 	<-d.PipelineFinished

--- a/search/collector/topn_test.go
+++ b/search/collector/topn_test.go
@@ -51,7 +51,7 @@ func TestTop10Scores(t *testing.T) {
 	aggs.Add("max_score", aggregations.Max(search.DocumentScore()))
 
 	collector := NewTopNCollector(10, 0, search.SortOrder{search.SortBy(search.DocumentScore()).Desc()})
-	dmi, err := collector.Collect(context.Background(), aggs, searcher)
+	dmi, err := collector.Collect(context.Background(), aggs, searcher, search.PoolTypeSlice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestTop10ScoresSkip10(t *testing.T) {
 	aggs.Add("max_score", aggregations.Max(search.DocumentScore()))
 
 	collector := NewTopNCollector(10, 10, search.SortOrder{search.SortBy(search.DocumentScore()).Desc()})
-	dmi, err := collector.Collect(context.Background(), aggs, searcher)
+	dmi, err := collector.Collect(context.Background(), aggs, searcher, search.PoolTypeSlice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +180,7 @@ func TestTop10ScoresSkip10Only9Hits(t *testing.T) {
 	aggs.Add("max_score", aggregations.Max(search.DocumentScore()))
 
 	collector := NewTopNCollector(10, 10, search.SortOrder{search.SortBy(search.DocumentScore()).Desc()})
-	dmi, err := collector.Collect(context.Background(), aggs, searcher)
+	dmi, err := collector.Collect(context.Background(), aggs, searcher, search.PoolTypeSlice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +220,7 @@ func TestPaginationSameScores(t *testing.T) {
 
 	// first get first 5 hits
 	collector := NewTopNCollector(5, 0, search.SortOrder{search.SortBy(search.DocumentScore()).Desc()})
-	dmi, err := collector.Collect(context.Background(), aggs, searcher)
+	dmi, err := collector.Collect(context.Background(), aggs, searcher, search.PoolTypeSlice)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestPaginationSameScores(t *testing.T) {
 
 	// now get next 5 hits
 	collector = NewTopNCollector(5, 5, search.SortOrder{search.SortBy(search.DocumentScore()).Desc()})
-	dmi, err = collector.Collect(context.Background(), aggs, searcher)
+	dmi, err = collector.Collect(context.Background(), aggs, searcher, search.PoolTypeSlice)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/search/doc_pool_test.go
+++ b/search/doc_pool_test.go
@@ -20,8 +20,8 @@ func TestDocumentMatchPool(t *testing.T) {
 	tooManyCalled := false
 
 	// create a pool
-	dmp := NewDocumentMatchPool(10, 0)
-	dmp.TooSmall = func(inner *DocumentMatchPool) *DocumentMatch {
+	dmp := NewDocumentMatchSlicePool(10, 0)
+	dmp.TooSmall = func(inner *DocumentMatchSlicePool) *DocumentMatch {
 		tooManyCalled = true
 		return &DocumentMatch{}
 	}

--- a/search/doc_sync_pool.go
+++ b/search/doc_sync_pool.go
@@ -35,10 +35,7 @@ type DocumentMatchSyncPool struct {
 func NewDocumentMatchSyncPool(size, sortSize int) *DocumentMatchSyncPool {
 	pool := &sync.Pool{
 		New: func() interface{} {
-			return &DocumentMatch{
-				SortValue: make([][]byte, sortSize),
-				NewAlloc:  true,
-			}
+			return &DocumentMatch{NewAlloc: true}
 		},
 	}
 
@@ -50,7 +47,7 @@ func NewDocumentMatchSyncPool(size, sortSize int) *DocumentMatchSyncPool {
 	i := 0
 	for i < size {
 		d := &startBlock[i]
-		d.SortValue = make([][]byte, sortSize)
+		d.SortValue = make([][]byte, size*sortSize)
 		poolSize += int64(d.Size())
 		pool.Put(d)
 		i++
@@ -85,6 +82,6 @@ func (p *DocumentMatchSyncPool) Put(d *DocumentMatch) {
 	}
 	// reset DocumentMatch before returning it to available pool
 	d.Reset()
-	atomic.AddInt64(&p.size, int64(d.Size()))
 	p.pool.Put(d)
+	atomic.AddInt64(&p.size, int64(d.Size()))
 }

--- a/search/doc_sync_pool.go
+++ b/search/doc_sync_pool.go
@@ -36,7 +36,7 @@ func NewDocumentMatchSyncPool(size, sortSize int) *DocumentMatchSyncPool {
 	pool := &sync.Pool{
 		New: func() interface{} {
 			return &DocumentMatch{
-				SortValue: make([][]byte, size*sortSize),
+				SortValue: make([][]byte, sortSize),
 				NewAlloc:  true,
 			}
 		},

--- a/search/doc_sync_pool.go
+++ b/search/doc_sync_pool.go
@@ -35,7 +35,10 @@ type DocumentMatchSyncPool struct {
 func NewDocumentMatchSyncPool(size, sortSize int) *DocumentMatchSyncPool {
 	pool := &sync.Pool{
 		New: func() interface{} {
-			return &DocumentMatch{NewAlloc: true}
+			return &DocumentMatch{
+				NewAlloc:  true,
+				SortValue: make([][]byte, 0, sortSize),
+			}
 		},
 	}
 
@@ -47,7 +50,7 @@ func NewDocumentMatchSyncPool(size, sortSize int) *DocumentMatchSyncPool {
 	i := 0
 	for i < size {
 		d := &startBlock[i]
-		d.SortValue = make([][]byte, size*sortSize)
+		d.SortValue = make([][]byte, 0, sortSize)
 		poolSize += int64(d.Size())
 		pool.Put(d)
 		i++
@@ -80,8 +83,8 @@ func (p *DocumentMatchSyncPool) Put(d *DocumentMatch) {
 	if d == nil {
 		return
 	}
-	// reset DocumentMatch before returning it to available pool
-	d.Reset()
+
+	d.Reset() // reset DocumentMatch before returning it to available pool
 	p.pool.Put(d)
 	atomic.AddInt64(&p.size, int64(d.Size()))
 }

--- a/search/doc_sync_pool.go
+++ b/search/doc_sync_pool.go
@@ -1,0 +1,90 @@
+//  Copyright (c) 2020 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package search
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// DocumentMatchSyncPool manages use/re-use of DocumentMatch instances
+// for searchers that are concurrent, avoiding reuse of the SortValue backing array
+// as seen in DocumentMatchSlicePool
+// it pre-allocates space in a sync.Pool with the expected number of instances.
+// It is thread-safe.
+type DocumentMatchSyncPool struct {
+	size int64
+	pool *sync.Pool
+}
+
+// NewDocumentMatchSyncPool will build a DocumentMatchSyncPool with memory
+// pre-allocated to accommodate the requested number of DocumentMatch
+// instances
+func NewDocumentMatchSyncPool(size, sortSize int) *DocumentMatchSyncPool {
+	pool := &sync.Pool{
+		New: func() interface{} {
+			return &DocumentMatch{
+				SortValue: make([][]byte, size*sortSize),
+				NewAlloc:  true,
+			}
+		},
+	}
+
+	// pre-allocate the expected number of instances
+	startBlock := make([]DocumentMatch, size)
+
+	var poolSize int64
+	// make these initial instances available in the pool
+	i := 0
+	for i < size {
+		d := &startBlock[i]
+		d.SortValue = make([][]byte, sortSize)
+		poolSize += int64(d.Size())
+		pool.Put(d)
+		i++
+	}
+
+	return &DocumentMatchSyncPool{pool: pool, size: poolSize}
+}
+
+// Get returns an available DocumentMatch from the pool
+// if the pool was not allocated with sufficient size, an allocation will
+// occur to satisfy this request.  As a side-effect this will grow the size
+// of the pool.
+func (p *DocumentMatchSyncPool) Get() *DocumentMatch {
+	d := p.pool.Get().(*DocumentMatch)
+	if !d.NewAlloc { // if it's not newly allocated, then this decreases the size of the pool
+		atomic.AddInt64(&p.size, int64(-d.Size()))
+	} else { // it's a new allocation, set it back to false.
+		d.NewAlloc = false
+	}
+	return d
+}
+
+// Size returns the size of the DocumentMatchSyncPool
+func (p *DocumentMatchSyncPool) Size() int64 {
+	return atomic.LoadInt64(&p.size)
+}
+
+// Put returns a DocumentMatch to the pool
+func (p *DocumentMatchSyncPool) Put(d *DocumentMatch) {
+	if d == nil {
+		return
+	}
+	// reset DocumentMatch before returning it to available pool
+	d.Reset()
+	atomic.AddInt64(&p.size, int64(d.Size()))
+	p.pool.Put(d)
+}

--- a/search/search.go
+++ b/search/search.go
@@ -104,6 +104,7 @@ type DocumentMatch struct {
 	FieldTermLocations []FieldTermLocation
 
 	PipelineFinished chan struct{}
+	Err              error
 }
 
 func (dm *DocumentMatch) SetReader(r MatchReader) {

--- a/search/search.go
+++ b/search/search.go
@@ -17,6 +17,7 @@ package search
 import (
 	"fmt"
 	"sort"
+	"sync"
 
 	segment "github.com/blugelabs/bluge_segment_api"
 
@@ -274,6 +275,7 @@ type SearcherOptions struct {
 
 // Context represents the context around a single search
 type Context struct {
+	lock              sync.RWMutex // prevent data race on dvReaders
 	DocumentMatchPool *DocumentMatchPool
 	dvReaders         map[DocumentValueReadable]segment.DocumentValueReader
 }
@@ -286,28 +288,39 @@ func NewSearchContext(size, sortSize int) *Context {
 }
 
 func (sc *Context) DocValueReaderForReader(r DocumentValueReadable, fields []string) (segment.DocumentValueReader, error) {
+	sc.lock.RLock()
 	dvReader := sc.dvReaders[r]
+	sc.lock.RUnlock()
+
 	if dvReader == nil {
 		var err error
 		dvReader, err = r.DocumentValueReader(fields)
 		if err != nil {
 			return nil, err
 		}
+
+		sc.lock.Lock()
 		sc.dvReaders[r] = dvReader
+		sc.lock.Unlock()
 	}
 	return dvReader, nil
 }
 
+// Size returns the search Context's size in memory.
+// IT SHOULD NOT BE CALLED INCESSANTLY FOR PERFORMANCE REASONS.
+// It can increase lock contention for the Context.DocumentMatchPool field
 func (sc *Context) Size() int {
 	sizeInBytes := reflectStaticSizeSearchContext + sizeOfPtr +
 		reflectStaticSizeDocumentMatchPool + sizeOfPtr
 
 	if sc.DocumentMatchPool != nil {
+		sc.DocumentMatchPool.lock.Lock()
 		for _, entry := range sc.DocumentMatchPool.avail {
 			if entry != nil {
 				sizeInBytes += entry.Size()
 			}
 		}
+		sc.DocumentMatchPool.lock.Unlock()
 	}
 
 	return sizeInBytes

--- a/search/search.go
+++ b/search/search.go
@@ -101,10 +101,6 @@ type DocumentMatch struct {
 	// be later incorporated into the Locations map when search
 	// results are completed
 	FieldTermLocations []FieldTermLocation
-
-	PipelineFinished chan struct{}
-	Err              error
-	NewAlloc         bool
 }
 
 func (dm *DocumentMatch) SetReader(r MatchReader) {

--- a/search/search.go
+++ b/search/search.go
@@ -94,13 +94,15 @@ type DocumentMatch struct {
 	docValues map[string][][]byte
 
 	// used to maintain natural index order
-	HitNumber int
+	HitNumber int64
 
 	// used to temporarily hold field term location information during
 	// search processing in an efficient, recycle-friendly manner, to
 	// be later incorporated into the Locations map when search
 	// results are completed
 	FieldTermLocations []FieldTermLocation
+
+	PipelineFinished chan struct{}
 }
 
 func (dm *DocumentMatch) SetReader(r MatchReader) {

--- a/search/searcher/search_boolean_test.go
+++ b/search/searcher/search_boolean_test.go
@@ -337,9 +337,7 @@ func TestBooleanSearch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
-		}
+		ctx := search.NewSearchContext(test.searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
@@ -352,7 +350,7 @@ func TestBooleanSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Explanation)
 				}
 			}
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = test.searcher.Next(ctx)
 			i++
 		}

--- a/search/searcher/search_conjunction.go
+++ b/search/searcher/search_conjunction.go
@@ -86,12 +86,12 @@ func (s *ConjunctionSearcher) Size() int {
 	return sizeInBytes
 }
 
-func (s *ConjunctionSearcher) initSearchers(ctx *search.Context) error {
+func (s *ConjunctionSearcher) initSearchers(ctx search.Context) error {
 	var err error
 	// get all searchers pointing at their first match
 	for i, searcher := range s.searchers {
 		if s.currs[i] != nil {
-			ctx.DocumentMatchPool.Put(s.currs[i])
+			ctx.PutDocumentMatchInPool(s.currs[i])
 		}
 		s.currs[i], err = searcher.Next(ctx)
 		if err != nil {
@@ -102,7 +102,7 @@ func (s *ConjunctionSearcher) initSearchers(ctx *search.Context) error {
 	return nil
 }
 
-func (s *ConjunctionSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (s *ConjunctionSearcher) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
 		if err != nil {
@@ -166,7 +166,7 @@ OUTER:
 		// so they all need to be bumped
 		for i, searcher := range s.searchers {
 			if s.currs[i] != rv {
-				ctx.DocumentMatchPool.Put(s.currs[i])
+				ctx.PutDocumentMatchInPool(s.currs[i])
 			}
 			s.currs[i], err = searcher.Next(ctx)
 			if err != nil {
@@ -181,7 +181,7 @@ OUTER:
 	return rv, nil
 }
 
-func (s *ConjunctionSearcher) Advance(ctx *search.Context, number uint64) (*search.DocumentMatch, error) {
+func (s *ConjunctionSearcher) Advance(ctx search.Context, number uint64) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
 		if err != nil {
@@ -200,9 +200,9 @@ func (s *ConjunctionSearcher) Advance(ctx *search.Context, number uint64) (*sear
 	return s.Next(ctx)
 }
 
-func (s *ConjunctionSearcher) advanceChild(ctx *search.Context, i int, number uint64) (err error) {
+func (s *ConjunctionSearcher) advanceChild(ctx search.Context, i int, number uint64) (err error) {
 	if s.currs[i] != nil {
-		ctx.DocumentMatchPool.Put(s.currs[i])
+		ctx.PutDocumentMatchInPool(s.currs[i])
 	}
 	s.currs[i], err = s.searchers[i].Advance(ctx, number)
 	return err

--- a/search/searcher/search_conjunction_test.go
+++ b/search/searcher/search_conjunction_test.go
@@ -182,9 +182,7 @@ func TestConjunctionSearch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(10, 0),
-		}
+		ctx := search.NewSearchContext(10, 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {

--- a/search/searcher/search_disjunction_heap.go
+++ b/search/searcher/search_disjunction_heap.go
@@ -82,7 +82,7 @@ func (s *DisjunctionHeapSearcher) Size() int {
 	return sizeInBytes
 }
 
-func (s *DisjunctionHeapSearcher) initSearchers(ctx *search.Context) error {
+func (s *DisjunctionHeapSearcher) initSearchers(ctx search.Context) error {
 	// alloc a single block of SearcherCurrs
 	block := make([]searcherCurr, len(s.searchers))
 
@@ -131,7 +131,7 @@ func (s *DisjunctionHeapSearcher) updateMatches() error {
 	return nil
 }
 
-func (s *DisjunctionHeapSearcher) Next(ctx *search.Context) (
+func (s *DisjunctionHeapSearcher) Next(ctx search.Context) (
 	*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
@@ -152,7 +152,7 @@ func (s *DisjunctionHeapSearcher) Next(ctx *search.Context) (
 		// invoke next on all the matching searchers
 		for _, matchingCurr := range s.matchingCurrs {
 			if matchingCurr.curr != rv {
-				ctx.DocumentMatchPool.Put(matchingCurr.curr)
+				ctx.PutDocumentMatchInPool(matchingCurr.curr)
 			}
 			curr, err := matchingCurr.searcher.Next(ctx)
 			if err != nil {
@@ -173,7 +173,7 @@ func (s *DisjunctionHeapSearcher) Next(ctx *search.Context) (
 	return rv, nil
 }
 
-func (s *DisjunctionHeapSearcher) Advance(ctx *search.Context,
+func (s *DisjunctionHeapSearcher) Advance(ctx search.Context,
 	number uint64) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
@@ -193,7 +193,7 @@ func (s *DisjunctionHeapSearcher) Advance(ctx *search.Context,
 	// advance them, using s.matchingCurrs as temp storage
 	for len(s.heap) > 0 && docNumberCompare(s.heap[0].curr.Number, number) < 0 {
 		searcherCurr := heap.Pop(s).(*searcherCurr)
-		ctx.DocumentMatchPool.Put(searcherCurr.curr)
+		ctx.PutDocumentMatchInPool(searcherCurr.curr)
 		curr, err := searcherCurr.searcher.Advance(ctx, number)
 		if err != nil {
 			return nil, err

--- a/search/searcher/search_disjunction_slice.go
+++ b/search/searcher/search_disjunction_slice.go
@@ -85,12 +85,12 @@ func (s *DisjunctionSliceSearcher) Size() int {
 	return sizeInBytes
 }
 
-func (s *DisjunctionSliceSearcher) initSearchers(ctx *search.Context) error {
+func (s *DisjunctionSliceSearcher) initSearchers(ctx search.Context) error {
 	var err error
 	// get all searchers pointing at their first match
 	for i, searcher := range s.searchers {
 		if s.currs[i] != nil {
-			ctx.DocumentMatchPool.Put(s.currs[i])
+			ctx.PutDocumentMatchInPool(s.currs[i])
 		}
 		s.currs[i], err = searcher.Next(ctx)
 		if err != nil {
@@ -139,7 +139,7 @@ func (s *DisjunctionSliceSearcher) updateMatches() error {
 	return nil
 }
 
-func (s *DisjunctionSliceSearcher) Next(ctx *search.Context) (
+func (s *DisjunctionSliceSearcher) Next(ctx search.Context) (
 	*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
@@ -162,7 +162,7 @@ func (s *DisjunctionSliceSearcher) Next(ctx *search.Context) (
 		for _, i := range s.matchingIdxs {
 			searcher := s.searchers[i]
 			if s.currs[i] != rv {
-				ctx.DocumentMatchPool.Put(s.currs[i])
+				ctx.PutDocumentMatchInPool(s.currs[i])
 			}
 			s.currs[i], err = searcher.Next(ctx)
 			if err != nil {
@@ -179,7 +179,7 @@ func (s *DisjunctionSliceSearcher) Next(ctx *search.Context) (
 	return rv, nil
 }
 
-func (s *DisjunctionSliceSearcher) Advance(ctx *search.Context,
+func (s *DisjunctionSliceSearcher) Advance(ctx search.Context,
 	number uint64) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
@@ -194,7 +194,7 @@ func (s *DisjunctionSliceSearcher) Advance(ctx *search.Context,
 			if s.currs[i].Number >= number {
 				continue
 			}
-			ctx.DocumentMatchPool.Put(s.currs[i])
+			ctx.PutDocumentMatchInPool(s.currs[i])
 		}
 		s.currs[i], err = searcher.Advance(ctx, number)
 		if err != nil {

--- a/search/searcher/search_disjunction_test.go
+++ b/search/searcher/search_disjunction_test.go
@@ -103,9 +103,7 @@ func TestDisjunctionSearch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
-		}
+		ctx := search.NewSearchContext(test.searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
@@ -118,7 +116,7 @@ func TestDisjunctionSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Explanation)
 				}
 			}
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = test.searcher.Next(ctx)
 			i++
 		}
@@ -145,9 +143,7 @@ func TestDisjunctionAdvance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := &search.Context{
-		DocumentMatchPool: search.NewDocumentMatchPool(martyOrDustinSearcher.DocumentMatchPoolSize(), 0),
-	}
+	ctx := search.NewSearchContext(martyOrDustinSearcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 	match, err := martyOrDustinSearcher.Advance(ctx, baseTestIndexReaderDirect.docNumByID("3"))
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/search/searcher/search_filter.go
+++ b/search/searcher/search_filter.go
@@ -42,7 +42,7 @@ func (f *FilteringSearcher) Size() int {
 		f.child.Size()
 }
 
-func (f *FilteringSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (f *FilteringSearcher) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	next, err := f.child.Next(ctx)
 	for next != nil && err == nil {
 		if f.accept(next) {
@@ -53,7 +53,7 @@ func (f *FilteringSearcher) Next(ctx *search.Context) (*search.DocumentMatch, er
 	return nil, err
 }
 
-func (f *FilteringSearcher) Advance(ctx *search.Context, number uint64) (*search.DocumentMatch, error) {
+func (f *FilteringSearcher) Advance(ctx search.Context, number uint64) (*search.DocumentMatch, error) {
 	adv, err := f.child.Advance(ctx, number)
 	if err != nil {
 		return nil, err

--- a/search/searcher/search_fuzzy_test.go
+++ b/search/searcher/search_fuzzy_test.go
@@ -104,9 +104,7 @@ func TestFuzzySearch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
-		}
+		ctx := search.NewSearchContext(test.searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
@@ -119,7 +117,7 @@ func TestFuzzySearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Explanation)
 				}
 			}
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = test.searcher.Next(ctx)
 			i++
 		}

--- a/search/searcher/search_geoboundingbox_test.go
+++ b/search/searcher/search_geoboundingbox_test.go
@@ -91,9 +91,8 @@ func testGeoBoundingBoxSearch(i search.Reader, minLon, minLat, maxLon, maxLat fl
 	if err != nil {
 		return nil, err
 	}
-	ctx := &search.Context{
-		DocumentMatchPool: search.NewDocumentMatchPool(gbs.DocumentMatchPoolSize(), 0),
-	}
+
+	ctx := search.NewSearchContext(gbs.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 	docMatch, err := gbs.Next(ctx)
 	for docMatch != nil && err == nil {
 		rv = append(rv, docMatch.Number)

--- a/search/searcher/search_geopointdistance_test.go
+++ b/search/searcher/search_geopointdistance_test.go
@@ -83,9 +83,8 @@ func testGeoPointDistanceSearch(i search.Reader, centerLon, centerLat, dist floa
 	if err != nil {
 		return nil, err
 	}
-	ctx := &search.Context{
-		DocumentMatchPool: search.NewDocumentMatchPool(gds.DocumentMatchPoolSize(), 0),
-	}
+
+	ctx := search.NewSearchContext(gds.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 	docMatch, err := gds.Next(ctx)
 	for docMatch != nil && err == nil {
 		rv = append(rv, docMatch.Number)

--- a/search/searcher/search_geopolygon_test.go
+++ b/search/searcher/search_geopolygon_test.go
@@ -165,9 +165,8 @@ func testGeoPolygonSearch(i search.Reader, polygon []geo.Point, field string) ([
 	if err != nil {
 		return nil, err
 	}
-	ctx := &search.Context{
-		DocumentMatchPool: search.NewDocumentMatchPool(gbs.DocumentMatchPoolSize(), 0),
-	}
+
+	ctx := search.NewSearchContext(gbs.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 	docMatch, err := gbs.Next(ctx)
 	for docMatch != nil && err == nil {
 		rv = append(rv, docMatch.Number)

--- a/search/searcher/search_match_all.go
+++ b/search/searcher/search_match_all.go
@@ -50,7 +50,7 @@ func (s *MatchAllSearcher) Count() uint64 {
 	return s.reader.Count()
 }
 
-func (s *MatchAllSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (s *MatchAllSearcher) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	tfd, err := s.reader.Next()
 	if err != nil {
 		return nil, err
@@ -67,7 +67,7 @@ func (s *MatchAllSearcher) Next(ctx *search.Context) (*search.DocumentMatch, err
 	return docMatch, nil
 }
 
-func (s *MatchAllSearcher) Advance(ctx *search.Context, number uint64) (*search.DocumentMatch, error) {
+func (s *MatchAllSearcher) Advance(ctx search.Context, number uint64) (*search.DocumentMatch, error) {
 	tfd, err := s.reader.Advance(number)
 	if err != nil {
 		return nil, err
@@ -96,8 +96,8 @@ func (s *MatchAllSearcher) DocumentMatchPoolSize() int {
 	return 1
 }
 
-func (s *MatchAllSearcher) buildDocumentMatch(ctx *search.Context, termMatch segment.Posting) *search.DocumentMatch {
-	rv := ctx.DocumentMatchPool.Get()
+func (s *MatchAllSearcher) buildDocumentMatch(ctx search.Context, termMatch segment.Posting) *search.DocumentMatch {
+	rv := ctx.GetDocumentMatchFromPool()
 	rv.SetReader(s.indexReader)
 	rv.Number = termMatch.Number()
 

--- a/search/searcher/search_match_all_test.go
+++ b/search/searcher/search_match_all_test.go
@@ -100,9 +100,7 @@ func TestMatchAllSearch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
-		}
+		ctx := search.NewSearchContext(test.searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
@@ -115,7 +113,7 @@ func TestMatchAllSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Explanation)
 				}
 			}
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = test.searcher.Next(ctx)
 			i++
 		}

--- a/search/searcher/search_match_none.go
+++ b/search/searcher/search_match_none.go
@@ -38,11 +38,11 @@ func (s *MatchNoneSearcher) Weight() float64 {
 
 func (s *MatchNoneSearcher) SetQueryNorm(_ float64) {}
 
-func (s *MatchNoneSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (s *MatchNoneSearcher) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	return nil, nil
 }
 
-func (s *MatchNoneSearcher) Advance(ctx *search.Context, number uint64) (*search.DocumentMatch, error) {
+func (s *MatchNoneSearcher) Advance(ctx search.Context, number uint64) (*search.DocumentMatch, error) {
 	return nil, nil
 }
 

--- a/search/searcher/search_match_none_test.go
+++ b/search/searcher/search_match_none_test.go
@@ -45,9 +45,7 @@ func TestMatchNoneSearch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
-		}
+		ctx := search.NewSearchContext(test.searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
@@ -60,7 +58,7 @@ func TestMatchNoneSearch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Explanation)
 				}
 			}
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = test.searcher.Next(ctx)
 			i++
 		}

--- a/search/searcher/search_phrase.go
+++ b/search/searcher/search_phrase.go
@@ -128,7 +128,7 @@ func NewSloppyMultiPhraseSearcher(indexReader search.Reader, terms [][]string, f
 	return &rv, nil
 }
 
-func (s *PhraseSearcher) initSearchers(ctx *search.Context) error {
+func (s *PhraseSearcher) initSearchers(ctx search.Context) error {
 	err := s.advanceNextMust(ctx)
 	if err != nil {
 		return err
@@ -138,12 +138,12 @@ func (s *PhraseSearcher) initSearchers(ctx *search.Context) error {
 	return nil
 }
 
-func (s *PhraseSearcher) advanceNextMust(ctx *search.Context) error {
+func (s *PhraseSearcher) advanceNextMust(ctx search.Context) error {
 	var err error
 
 	if s.mustSearcher != nil {
 		if s.currMust != nil {
-			ctx.DocumentMatchPool.Put(s.currMust)
+			ctx.PutDocumentMatchInPool(s.currMust)
 		}
 		s.currMust, err = s.mustSearcher.Next(ctx)
 		if err != nil {
@@ -154,7 +154,7 @@ func (s *PhraseSearcher) advanceNextMust(ctx *search.Context) error {
 	return nil
 }
 
-func (s *PhraseSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (s *PhraseSearcher) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
 		if err != nil {
@@ -350,7 +350,7 @@ func editDistance(p1, p2 int) int {
 	return dist
 }
 
-func (s *PhraseSearcher) Advance(ctx *search.Context, number uint64) (*search.DocumentMatch, error) {
+func (s *PhraseSearcher) Advance(ctx search.Context, number uint64) (*search.DocumentMatch, error) {
 	if !s.initialized {
 		err := s.initSearchers(ctx)
 		if err != nil {
@@ -361,7 +361,7 @@ func (s *PhraseSearcher) Advance(ctx *search.Context, number uint64) (*search.Do
 		if s.currMust.Number >= number {
 			return s.Next(ctx)
 		}
-		ctx.DocumentMatchPool.Put(s.currMust)
+		ctx.PutDocumentMatchInPool(s.currMust)
 	}
 	if s.currMust == nil {
 		return nil, nil

--- a/search/searcher/search_phrase_test.go
+++ b/search/searcher/search_phrase_test.go
@@ -64,9 +64,7 @@ func TestPhraseSearch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
-		}
+		ctx := search.NewSearchContext(test.searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
@@ -93,7 +91,7 @@ func TestPhraseSearch(t *testing.T) {
 				}
 			}
 
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = test.searcher.Next(ctx)
 			i++
 		}
@@ -130,14 +128,13 @@ func TestMultiPhraseSearch(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(searcher.DocumentMatchPoolSize(), 0),
-		}
+
+		ctx := search.NewSearchContext(searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := searcher.Next(ctx)
 		var actualIds []uint64
 		for err == nil && next != nil {
 			actualIds = append(actualIds, next.Number)
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = searcher.Next(ctx)
 		}
 		if err != nil {
@@ -212,14 +209,13 @@ func TestSloppyMultiPhraseSearch(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(searcher.DocumentMatchPoolSize(), 0),
-		}
+
+		ctx := search.NewSearchContext(searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := searcher.Next(ctx)
 		actualIds := []uint64{}
 		for err == nil && next != nil {
 			actualIds = append(actualIds, next.Number)
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = searcher.Next(ctx)
 		}
 		if err != nil {

--- a/search/searcher/search_regexp_test.go
+++ b/search/searcher/search_regexp_test.go
@@ -64,9 +64,7 @@ func TestRegexpStringSearchScorch(t *testing.T) {
 			}
 		}()
 
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(test.searcher.DocumentMatchPoolSize(), 0),
-		}
+		ctx := search.NewSearchContext(test.searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := test.searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
@@ -80,7 +78,7 @@ func TestRegexpStringSearchScorch(t *testing.T) {
 					t.Logf("scoring explanation: %s", next.Explanation)
 				}
 			}
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = test.searcher.Next(ctx)
 			i++
 		}

--- a/search/searcher/search_term.go
+++ b/search/searcher/search_term.go
@@ -76,7 +76,7 @@ func (s *TermSearcher) Count() uint64 {
 	return s.reader.Count()
 }
 
-func (s *TermSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) {
+func (s *TermSearcher) Next(ctx search.Context) (*search.DocumentMatch, error) {
 	termMatch, err := s.reader.Next()
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (s *TermSearcher) Next(ctx *search.Context) (*search.DocumentMatch, error) 
 	return docMatch, nil
 }
 
-func (s *TermSearcher) Advance(ctx *search.Context, number uint64) (*search.DocumentMatch, error) {
+func (s *TermSearcher) Advance(ctx search.Context, number uint64) (*search.DocumentMatch, error) {
 	termMatch, err := s.reader.Advance(number)
 	if err != nil {
 		return nil, err
@@ -132,8 +132,8 @@ func (s *TermSearcher) Optimize(kind string, octx segment.OptimizableContext) (
 	return nil, nil
 }
 
-func (s *TermSearcher) buildDocumentMatch(ctx *search.Context, termMatch segment.Posting) *search.DocumentMatch {
-	rv := ctx.DocumentMatchPool.Get()
+func (s *TermSearcher) buildDocumentMatch(ctx search.Context, termMatch segment.Posting) *search.DocumentMatch {
+	rv := ctx.GetDocumentMatchFromPool()
 	rv.SetReader(s.indexReader)
 	rv.Number = termMatch.Number()
 

--- a/search/searcher/search_term_range_test.go
+++ b/search/searcher/search_term_range_test.go
@@ -209,15 +209,13 @@ func TestTermRangeSearch(t *testing.T) {
 		}
 
 		var got []uint64
-		ctx := &search.Context{
-			DocumentMatchPool: search.NewDocumentMatchPool(
-				searcher.DocumentMatchPoolSize(), 0),
-		}
+
+		ctx := search.NewSearchContext(searcher.DocumentMatchPoolSize(), 0, search.PoolTypeSlice)
 		next, err := searcher.Next(ctx)
 		i := 0
 		for err == nil && next != nil {
 			got = append(got, next.Number)
-			ctx.DocumentMatchPool.Put(next)
+			ctx.PutDocumentMatchInPool(next)
 			next, err = searcher.Next(ctx)
 			i++
 		}

--- a/search/searcher/search_term_test.go
+++ b/search/searcher/search_term_test.go
@@ -90,9 +90,7 @@ func TestTermSearcher(t *testing.T) {
 		t.Errorf("expected count of 9, got %d", searcher.Count())
 	}
 
-	ctx := &search.Context{
-		DocumentMatchPool: search.NewDocumentMatchPool(1, 0),
-	}
+	ctx := search.NewSearchContext(1, 0, search.PoolTypeSlice)
 	docMatch, err := searcher.Next(ctx)
 	if err != nil {
 		t.Errorf("expected result, got %v", err)
@@ -101,7 +99,7 @@ func TestTermSearcher(t *testing.T) {
 	if docMatch.Number != numberA {
 		t.Errorf("expected result number to be %d, got %d", numberA, docMatch.Number)
 	}
-	ctx.DocumentMatchPool.Put(docMatch)
+	ctx.PutDocumentMatchInPool(docMatch)
 	docMatch, err = searcher.Advance(ctx, indexReader.docNumByID("c"))
 	if err != nil {
 		t.Errorf("expected result, got %v", err)
@@ -112,7 +110,7 @@ func TestTermSearcher(t *testing.T) {
 	}
 
 	// try advancing past end
-	ctx.DocumentMatchPool.Put(docMatch)
+	ctx.PutDocumentMatchInPool(docMatch)
 	docMatch, err = searcher.Advance(ctx, 999)
 	if err != nil {
 		t.Fatal(err)
@@ -122,7 +120,7 @@ func TestTermSearcher(t *testing.T) {
 	}
 
 	// try pushing next past end
-	ctx.DocumentMatchPool.Put(docMatch)
+	ctx.PutDocumentMatchInPool(docMatch)
 	docMatch, err = searcher.Next(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/search/size.go
+++ b/search/size.go
@@ -29,11 +29,13 @@ func init() {
 	reflectStaticSizeExplanation = int(reflect.TypeOf(e).Size())
 	var dm DocumentMatch
 	reflectStaticSizeDocumentMatch = int(reflect.TypeOf(dm).Size())
-	var sc Context
-	reflectStaticSizeSearchContext = int(reflect.TypeOf(sc).Size())
+	var sc = newSliceContext(0, 0)
+	reflectStaticSizeSliceSearchContext = int(reflect.TypeOf(sc).Size())
+	var spc = newSearchSyncPoolContext(0, 0)
+	reflectStaticSizeSyncPoolSearchContext = int(reflect.TypeOf(spc).Size())
 	var l Location
 	reflectStaticSizeLocation = int(reflect.TypeOf(l).Size())
-	var dmp DocumentMatchPool
+	var dmp DocumentMatchSlicePool
 	reflectStaticSizeDocumentMatchPool = int(reflect.TypeOf(dmp).Size())
 }
 
@@ -43,6 +45,7 @@ var sizeOfSlice int
 
 var reflectStaticSizeExplanation int
 var reflectStaticSizeDocumentMatch int
-var reflectStaticSizeSearchContext int
+var reflectStaticSizeSliceSearchContext int
+var reflectStaticSizeSyncPoolSearchContext int
 var reflectStaticSizeLocation int
 var reflectStaticSizeDocumentMatchPool int

--- a/search/size.go
+++ b/search/size.go
@@ -32,7 +32,7 @@ func init() {
 	var sc sliceContext
 	reflectStaticSizeSliceSearchContext = int(reflect.TypeOf(sc).Size())
 	var spc syncPoolContext
-	reflectStaticSizeSyncPoolSearchContext = int(reflect.TypeOf(spc).Size()) //nolint:govet
+	reflectStaticSizeSyncPoolSearchContext = int(reflect.TypeOf(spc).Size())
 	var l Location
 	reflectStaticSizeLocation = int(reflect.TypeOf(l).Size())
 	var dmsp DocumentMatchSlicePool

--- a/search/size.go
+++ b/search/size.go
@@ -29,14 +29,16 @@ func init() {
 	reflectStaticSizeExplanation = int(reflect.TypeOf(e).Size())
 	var dm DocumentMatch
 	reflectStaticSizeDocumentMatch = int(reflect.TypeOf(dm).Size())
-	var sc = newSliceContext(0, 0)
+	var sc sliceContext
 	reflectStaticSizeSliceSearchContext = int(reflect.TypeOf(sc).Size())
-	var spc = newSearchSyncPoolContext(0, 0)
+	var spc syncPoolContext
 	reflectStaticSizeSyncPoolSearchContext = int(reflect.TypeOf(spc).Size())
 	var l Location
 	reflectStaticSizeLocation = int(reflect.TypeOf(l).Size())
-	var dmp DocumentMatchSlicePool
-	reflectStaticSizeDocumentMatchPool = int(reflect.TypeOf(dmp).Size())
+	var dmsp DocumentMatchSlicePool
+	reflectStaticSizeDocumentMatchSlicePool = int(reflect.TypeOf(dmsp).Size())
+	var dssp DocumentMatchSyncPool
+	reflectStaticSizeDocumentMatchSyncPool = int(reflect.TypeOf(dssp).Size())
 }
 
 var sizeOfPtr int
@@ -48,4 +50,5 @@ var reflectStaticSizeDocumentMatch int
 var reflectStaticSizeSliceSearchContext int
 var reflectStaticSizeSyncPoolSearchContext int
 var reflectStaticSizeLocation int
-var reflectStaticSizeDocumentMatchPool int
+var reflectStaticSizeDocumentMatchSlicePool int
+var reflectStaticSizeDocumentMatchSyncPool int

--- a/search/size.go
+++ b/search/size.go
@@ -32,7 +32,7 @@ func init() {
 	var sc sliceContext
 	reflectStaticSizeSliceSearchContext = int(reflect.TypeOf(sc).Size())
 	var spc syncPoolContext
-	reflectStaticSizeSyncPoolSearchContext = int(reflect.TypeOf(spc).Size())
+	reflectStaticSizeSyncPoolSearchContext = int(reflect.TypeOf(spc).Size()) //nolint:govet
 	var l Location
 	reflectStaticSizeLocation = int(reflect.TypeOf(l).Size())
 	var dmsp DocumentMatchSlicePool

--- a/search/slice_context.go
+++ b/search/slice_context.go
@@ -5,7 +5,7 @@ import (
 )
 
 // sliceContext represents the context around a single search
-// It is not safe for concurrent use.
+// It is not safe  for concurrent use.
 type sliceContext struct {
 	DocumentMatchPool *DocumentMatchSlicePool
 	dvReaders         map[DocumentValueReadable]segment.DocumentValueReader

--- a/search/slice_context.go
+++ b/search/slice_context.go
@@ -1,0 +1,75 @@
+package search
+
+import (
+	segment "github.com/blugelabs/bluge_segment_api"
+)
+
+// sliceContext represents the context around a single search
+type sliceContext struct {
+	DocumentMatchPool *DocumentMatchSlicePool
+	dvReaders         map[DocumentValueReadable]segment.DocumentValueReader
+}
+
+func newSliceContext(size, sortSize int) *sliceContext {
+	return &sliceContext{
+		DocumentMatchPool: NewDocumentMatchSlicePool(size, sortSize),
+		dvReaders:         make(map[DocumentValueReadable]segment.DocumentValueReader),
+	}
+}
+
+type PoolType string
+
+const (
+	PoolTypeSlice    PoolType = "slice"
+	PoolTypeSyncPool PoolType = "sync_pool"
+)
+
+func NewSearchContext(size, sortSize int, poolType PoolType) Context {
+	switch poolType {
+	case PoolTypeSlice:
+		return newSliceContext(size, sortSize)
+	case PoolTypeSyncPool:
+		return newSearchSyncPoolContext(size, sortSize)
+	default:
+		panic("unknown pool type: " + poolType)
+	}
+}
+
+func (sc *sliceContext) DocValueReaderForReader(r DocumentValueReadable, fields []string) (segment.DocumentValueReader, error) {
+	dvReader := sc.dvReaders[r]
+
+	if dvReader == nil {
+		var err error
+		dvReader, err = r.DocumentValueReader(fields)
+		if err != nil {
+			return nil, err
+		}
+
+		sc.dvReaders[r] = dvReader
+	}
+	return dvReader, nil
+}
+
+// Size returns the sliceContext 's size in memory.
+func (sc *sliceContext) Size() int64 {
+	sizeInBytes := reflectStaticSizeSliceSearchContext + sizeOfPtr +
+		reflectStaticSizeDocumentMatchPool + sizeOfPtr
+
+	if sc.DocumentMatchPool != nil {
+		for _, entry := range sc.DocumentMatchPool.avail {
+			if entry != nil {
+				sizeInBytes += entry.Size()
+			}
+		}
+	}
+
+	return int64(sizeInBytes)
+}
+
+func (sc *sliceContext) GetDocumentMatchFromPool() *DocumentMatch {
+	return sc.DocumentMatchPool.Get()
+}
+
+func (sc *sliceContext) PutDocumentMatchInPool(d *DocumentMatch) {
+	sc.DocumentMatchPool.Put(d)
+}

--- a/search/slice_context.go
+++ b/search/slice_context.go
@@ -5,6 +5,7 @@ import (
 )
 
 // sliceContext represents the context around a single search
+// It is not safe for concurrent use.
 type sliceContext struct {
 	DocumentMatchPool *DocumentMatchSlicePool
 	dvReaders         map[DocumentValueReadable]segment.DocumentValueReader
@@ -53,7 +54,7 @@ func (sc *sliceContext) DocValueReaderForReader(r DocumentValueReadable, fields 
 // Size returns the sliceContext 's size in memory.
 func (sc *sliceContext) Size() int64 {
 	sizeInBytes := reflectStaticSizeSliceSearchContext + sizeOfPtr +
-		reflectStaticSizeDocumentMatchPool + sizeOfPtr
+		reflectStaticSizeDocumentMatchSlicePool + sizeOfPtr
 
 	if sc.DocumentMatchPool != nil {
 		for _, entry := range sc.DocumentMatchPool.avail {

--- a/search/sync_pool_context.go
+++ b/search/sync_pool_context.go
@@ -1,0 +1,64 @@
+package search
+
+import (
+	"sync"
+
+	segment "github.com/blugelabs/bluge_segment_api"
+)
+
+// syncPoolContext represents the context around a single search
+type syncPoolContext struct {
+	lock              sync.RWMutex // prevent data race on dvReaders
+	DocumentMatchPool *DocumentMatchSyncPool
+	dvReaders         map[DocumentValueReadable]segment.DocumentValueReader
+}
+
+func newSearchSyncPoolContext(size, sortSize int) Context {
+	return &syncPoolContext{
+		DocumentMatchPool: NewDocumentMatchSyncPool(size, sortSize),
+		dvReaders:         make(map[DocumentValueReadable]segment.DocumentValueReader),
+	}
+}
+
+func (sc *syncPoolContext) DocValueReaderForReader(r DocumentValueReadable, fields []string) (segment.DocumentValueReader, error) {
+	sc.lock.RLock()
+	dvReader := sc.dvReaders[r]
+	sc.lock.RUnlock()
+
+	if dvReader == nil {
+		var err error
+		dvReader, err = r.DocumentValueReader(fields)
+		if err != nil {
+			return nil, err
+		}
+
+		sc.lock.Lock()
+		sc.dvReaders[r] = dvReader
+		sc.lock.Unlock()
+	}
+	return dvReader, nil
+}
+
+// Size returns the search syncPoolContext's size in memory.
+// IT SHOULD NOT BE CALLED INCESSANTLY FOR PERFORMANCE REASONS.
+// It can increase lock contention for the syncPoolContext.DocumentMatchPool field
+func (sc *syncPoolContext) Size() int64 {
+	sizeInBytes := reflectStaticSizeSyncPoolSearchContext + sizeOfPtr +
+		reflectStaticSizeDocumentMatchPool + sizeOfPtr
+
+	var dpSize int64
+	if sc.DocumentMatchPool != nil {
+		dpSize = sc.DocumentMatchPool.Size()
+	}
+
+	totalSize := dpSize + int64(sizeInBytes)
+	return totalSize
+}
+
+func (sc *syncPoolContext) GetDocumentMatchFromPool() *DocumentMatch {
+	return sc.DocumentMatchPool.Get()
+}
+
+func (sc *syncPoolContext) PutDocumentMatchInPool(d *DocumentMatch) {
+	sc.DocumentMatchPool.Put(d)
+}

--- a/search/sync_pool_context.go
+++ b/search/sync_pool_context.go
@@ -1,15 +1,12 @@
 package search
 
 import (
-	"sync"
-
 	segment "github.com/blugelabs/bluge_segment_api"
 )
 
 // syncPoolContext represents the context around a single search
 // It is safe for concurrent use.
 type syncPoolContext struct {
-	lock              sync.RWMutex // prevent data race on dvReaders
 	DocumentMatchPool *DocumentMatchSyncPool
 	dvReaders         map[DocumentValueReadable]segment.DocumentValueReader
 }
@@ -22,9 +19,7 @@ func newSearchSyncPoolContext(size, sortSize int) Context {
 }
 
 func (sc *syncPoolContext) DocValueReaderForReader(r DocumentValueReadable, fields []string) (segment.DocumentValueReader, error) {
-	sc.lock.RLock()
 	dvReader := sc.dvReaders[r]
-	sc.lock.RUnlock()
 
 	if dvReader == nil {
 		var err error
@@ -33,9 +28,7 @@ func (sc *syncPoolContext) DocValueReaderForReader(r DocumentValueReadable, fiel
 			return nil, err
 		}
 
-		sc.lock.Lock()
 		sc.dvReaders[r] = dvReader
-		sc.lock.Unlock()
 	}
 	return dvReader, nil
 }

--- a/search/sync_pool_context.go
+++ b/search/sync_pool_context.go
@@ -17,7 +17,7 @@ type syncPoolContext struct {
 func newSearchSyncPoolContext(size, sortSize int) Context {
 	return &syncPoolContext{
 		DocumentMatchPool: NewDocumentMatchSyncPool(size, sortSize),
-		dvReaders:         make(map[DocumentValueReadable]segment.DocumentValueReader),
+		dvReaders:         make(map[DocumentValueReadable]segment.DocumentValueReader, size/2),
 	}
 }
 

--- a/search/sync_pool_context.go
+++ b/search/sync_pool_context.go
@@ -14,7 +14,7 @@ type syncPoolContext struct {
 func newSearchSyncPoolContext(size, sortSize int) Context {
 	return &syncPoolContext{
 		DocumentMatchPool: NewDocumentMatchSyncPool(size, sortSize),
-		dvReaders:         make(map[DocumentValueReadable]segment.DocumentValueReader, size/2),
+		dvReaders:         make(map[DocumentValueReadable]segment.DocumentValueReader),
 	}
 }
 

--- a/search/sync_pool_context.go
+++ b/search/sync_pool_context.go
@@ -7,6 +7,7 @@ import (
 )
 
 // syncPoolContext represents the context around a single search
+// It is safe for concurrent use.
 type syncPoolContext struct {
 	lock              sync.RWMutex // prevent data race on dvReaders
 	DocumentMatchPool *DocumentMatchSyncPool
@@ -40,11 +41,9 @@ func (sc *syncPoolContext) DocValueReaderForReader(r DocumentValueReadable, fiel
 }
 
 // Size returns the search syncPoolContext's size in memory.
-// IT SHOULD NOT BE CALLED INCESSANTLY FOR PERFORMANCE REASONS.
-// It can increase lock contention for the syncPoolContext.DocumentMatchPool field
 func (sc *syncPoolContext) Size() int64 {
 	sizeInBytes := reflectStaticSizeSyncPoolSearchContext + sizeOfPtr +
-		reflectStaticSizeDocumentMatchPool + sizeOfPtr
+		reflectStaticSizeDocumentMatchSyncPool + sizeOfPtr
 
 	var dpSize int64
 	if sc.DocumentMatchPool != nil {

--- a/size.go
+++ b/size.go
@@ -34,7 +34,9 @@ func init() {
 
 	var sc = search.NewSearchContext(0, 0, search.PoolTypeSlice)
 	var spc = search.NewSearchContext(0, 0, search.PoolTypeSyncPool)
-	searchContextEmptySize = int(sc.Size()) // down-casting might give inaccurate results, depending on system arch, but we usually use 64bit so this should be fine
+
+	// down-casting might give inaccurate results, depending on system arch, but we usually use 64bit so this should be fine
+	searchContextEmptySize = int(sc.Size())
 	if spc.Size() > sc.Size() {
 		searchContextEmptySize = int(spc.Size())
 	}

--- a/size.go
+++ b/size.go
@@ -31,8 +31,14 @@ var sizeOfBool int
 func init() {
 	var dm search.DocumentMatch
 	documentMatchEmptySize = dm.Size()
-	var sc search.Context
-	searchContextEmptySize = sc.Size()
+
+	var sc = search.NewSearchContext(0, 0, search.PoolTypeSlice)
+	var spc = search.NewSearchContext(0, 0, search.PoolTypeSyncPool)
+	searchContextEmptySize = int(sc.Size()) // down-casting might give inaccurate results, depending on system arch, but we usually use 64bit so this should be fine
+	if spc.Size() > sc.Size() {
+		searchContextEmptySize = int(spc.Size())
+	}
+
 	var f TermField
 	reflectStaticSizeBaseField = int(reflect.TypeOf(f).Size())
 	var slice []int


### PR DESCRIPTION
- introduce concurrency into (hc *TopNCollector).Collect
- break (hc *TopNCollector).collectSingle into separate pipeline blocks, allowing more concurrent processing

should fix [this](https://github.com/zinclabs/zinc/issues/313).